### PR TITLE
Fix building PitchTrack from toplevel CMakeLists.txt

### DIFF
--- a/plugins/PitchTrack/CMakeLists.txt
+++ b/plugins/PitchTrack/CMakeLists.txt
@@ -63,8 +63,8 @@ juce_generate_juce_header(${PLUGIN_NAME})
 # Extra include directories for Q library
 target_include_directories(${PLUGIN_NAME}
     PRIVATE
-        ${CMAKE_SOURCE_DIR}/../../modules/Q/q_lib/include
-        ${CMAKE_SOURCE_DIR}/../../modules/infra/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../modules/Q/q_lib/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../modules/infra/include
 )
 
 target_compile_definitions(${PLUGIN_NAME}


### PR DESCRIPTION
The current source dirrectory does not depend on which CMakeLists.txt is used.